### PR TITLE
Clean up descendants on exit fallback, harden process death checks

### DIFF
--- a/src/processExec.ts
+++ b/src/processExec.ts
@@ -74,6 +74,11 @@ export function execWithHardTimeout(
 			settled = true;
 			clearTimeout(timeoutTimer);
 			if (graceTimer) clearTimeout(graceTimer);
+			// Stop accumulating output and release the pipe read-ends so a
+			// surviving descendant cannot keep handles (and the event loop)
+			// alive after the caller has its answer
+			child.stdout?.destroy();
+			child.stderr?.destroy();
 			settle();
 		};
 
@@ -106,11 +111,17 @@ export function execWithHardTimeout(
 
 		// 'close' delivers all output but never fires while an orphan holds the
 		// pipes; 'exit' always fires. Use 'close' when it comes, with 'exit' +
-		// grace period as the settlement guarantee.
+		// grace period as the settlement guarantee. Settling through the grace
+		// fallback means a descendant still holds the pipes, so the leftover
+		// process group is killed before settling — matching exec semantics:
+		// when the command is done, nothing of it should remain.
 		child.on('close', (code) => settleWithCode(code));
 		child.on('exit', (code) => {
 			if (settled) return;
-			graceTimer = setTimeout(() => settleWithCode(code), STDIO_FLUSH_GRACE_MS);
+			graceTimer = setTimeout(() => {
+				killProcessTree(childProcess, child);
+				settleWithCode(code);
+			}, STDIO_FLUSH_GRACE_MS);
 		});
 	});
 }

--- a/test/unit/processExec.test.ts
+++ b/test/unit/processExec.test.ts
@@ -7,6 +7,40 @@ import { execWithHardTimeout } from '../../src/processExec';
 
 const env = process.env as Record<string, string | undefined>;
 
+// Zombie-aware liveness check: after a group SIGKILL the process can linger
+// briefly as a zombie awaiting reaping, and kill(pid, 0) still succeeds for
+// zombies. Poll until the pid is gone or shows state Z, both of which count
+// as dead.
+async function waitForProcessDeath(pid: number, timeoutMs = 3000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		let signalable = true;
+		try {
+			process.kill(pid, 0);
+		} catch {
+			signalable = false;
+		}
+		if (!signalable) return true;
+
+		const ps = childProcess.spawnSync('ps', ['-o', 'state=', '-p', String(pid)], { encoding: 'utf8' });
+		const state = (ps.stdout || '').trim();
+		if (ps.status !== 0 || state === '' || state.startsWith('Z')) return true;
+
+		if (Date.now() > deadline) {
+			// Clean up so a failing test does not leak a long-running sleeper
+			try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+			return false;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+}
+
+function readPid(pidFile: string): number {
+	const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+	expect(pid).toBeGreaterThan(0);
+	return pid;
+}
+
 describe('execWithHardTimeout', () => {
 	test('resolves with stdout for a successful command', async () => {
 		const result = await execWithHardTimeout(childProcess, 'echo hello', env, 5000);
@@ -38,30 +72,21 @@ describe('execWithHardTimeout', () => {
 			execWithHardTimeout(childProcess, command, env, 300)
 		).rejects.toMatchObject({ code: 'ETIMEDOUT' });
 
-		// Give SIGKILL a moment to be delivered
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		const grandchildPid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
-		expect(grandchildPid).toBeGreaterThan(0);
-
-		let alive = true;
-		try {
-			process.kill(grandchildPid, 0);
-		} catch {
-			alive = false;
-		}
-		if (alive) {
-			// Clean up so a failing test does not leak a 30s sleeper
-			try { process.kill(grandchildPid, 'SIGKILL'); } catch { /* already gone */ }
-		}
-		expect(alive).toBe(false);
+		expect(await waitForProcessDeath(readPid(pidFile))).toBe(true);
 	});
 
 	test('settles even if an orphan holds the stdio pipes open after exit', async () => {
 		// A background grandchild inherits the pipes and outlives the shell;
 		// promisified exec would wait for 'close' forever in this situation.
-		const command = 'sleep 30 & echo done';
+		const dir = mkdtempSync(join(tmpdir(), 'pexec-orphan-'));
+		const pidFile = join(dir, 'pid');
+		const command = `sleep 30 & echo $! > "${pidFile}"; echo done`;
+
 		const result = await execWithHardTimeout(childProcess, command, env, 5000);
 		expect(result.stdout).toContain('done');
+
+		// Settling through the exit fallback must not leave the descendant
+		// running with the pipes open — the group is cleaned up on settle.
+		expect(await waitForProcessDeath(readPid(pidFile))).toBe(true);
 	}, 10000);
 });


### PR DESCRIPTION
Addresses both review findings on PR #4:

1. **Exit-fallback cleanup.** When a command exits but a descendant still holds the stdio pipes (settlement via the exit + grace path), execWithHardTimeout now kills the leftover process group and destroys the pipe read-ends before settling, so nothing of the command survives and no open handles can keep the event loop alive. The orphan-pipe test now asserts the descendant is dead after the promise resolves — it failed against the previous implementation and passes with this one.

2. **Zombie-aware test liveness checks.** kill(pid, 0) succeeds for zombie processes, which could flake the tree-kill assertions in slow-reaping environments. Tests now poll for death and treat state Z as dead via ps.

No version bump: no user-observable behavior changes in the shipped transcription flows (the whisper scripts always wait for their children, so the exit-fallback-with-descendants path does not occur there); these fixes land on master for the next release.

Verification: npm test (61 tests) and npm run build pass.