### PR TITLE
Add Windows CI, platform-aware browser options, cross-platform exec tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/main.ts
+++ b/main.ts
@@ -148,7 +148,7 @@ interface TikTokerSettings {
 	transcriptionApi: 'none' | 'whisper-local' | 'assemblyai';
 	whisperScriptPath: string;
 	whisperModel: 'tiny' | 'base' | 'small' | 'medium' | 'large';
-	whisperBrowser: 'chrome' | 'safari';
+	whisperBrowser: 'chrome' | 'safari' | 'edge' | 'firefox';
 	apiKey: string;
 	handlePrivateVideos: 'create-empty' | 'skip' | 'show-error';
 	duplicateFileHandling: 'replace' | 'duplicate' | 'skip';
@@ -2881,14 +2881,22 @@ class TikTokerSettingTab extends PluginSettingTab {
 			new Setting(modelSection)
 				.setName('Browser for cookies')
 				.setDesc('Which browser to use for cookie extraction')
-				.addDropdown(dropdown => dropdown
-					.addOption('chrome', 'Chrome')
-					.addOption('safari', 'Safari')
-					.setValue(this.plugin.settings.whisperBrowser)
-					.onChange(async (value: string) => {
-						this.plugin.settings.whisperBrowser = value as 'chrome' | 'safari';
-						await this.plugin.saveSettings();
-					}));
+				.addDropdown(dropdown => {
+					// Safari cookies only exist on macOS; Windows gets Edge instead
+					dropdown.addOption('chrome', 'Chrome');
+					if (Platform.isWin) {
+						dropdown.addOption('edge', 'Edge');
+					} else {
+						dropdown.addOption('safari', 'Safari');
+					}
+					dropdown.addOption('firefox', 'Firefox');
+					dropdown
+						.setValue(this.plugin.settings.whisperBrowser)
+						.onChange(async (value: string) => {
+							this.plugin.settings.whisperBrowser = value as TikTokerSettings['whisperBrowser'];
+							await this.plugin.saveSettings();
+						});
+				});
 
 			const testSection = this.createCollapsibleSection(container, 'Setup & testing');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ export interface TikTokerSettings {
 	transcriptionApi: 'none' | 'whisper-local' | 'assemblyai';
 	whisperScriptPath: string;
 	whisperModel: 'tiny' | 'base' | 'small' | 'medium' | 'large';
-	whisperBrowser: 'chrome' | 'safari';
+	whisperBrowser: 'chrome' | 'safari' | 'edge' | 'firefox';
 	apiKey: string;
 	handlePrivateVideos: 'create-empty' | 'skip' | 'show-error';
 	duplicateFileHandling: 'replace' | 'duplicate' | 'skip';

--- a/test/unit/processExec.test.ts
+++ b/test/unit/processExec.test.ts
@@ -41,24 +41,31 @@ function readPid(pidFile: string): number {
 	return pid;
 }
 
+// The POSIX-shell fixtures (sh syntax, $!, ps) cannot run on Windows; the
+// cross-platform tests below use node -e so they exercise the Windows spawn
+// and taskkill paths on Windows CI.
+const posixOnly = describe.skipIf(process.platform === 'win32');
+
 describe('execWithHardTimeout', () => {
 	test('resolves with stdout for a successful command', async () => {
-		const result = await execWithHardTimeout(childProcess, 'echo hello', env, 5000);
+		const result = await execWithHardTimeout(childProcess, 'node -e "console.log(\'hello\')"', env, 15000);
 		expect(result.stdout.trim()).toBe('hello');
-	});
+	}, 20000);
 
 	test('rejects with stderr in the message for a failing command', async () => {
 		await expect(
-			execWithHardTimeout(childProcess, 'echo boom >&2; exit 3', env, 5000)
+			execWithHardTimeout(childProcess, 'node -e "console.error(\'boom\'); process.exit(3)"', env, 15000)
 		).rejects.toThrow(/boom/);
-	});
+	}, 20000);
 
 	test('rejects with ETIMEDOUT on timeout', async () => {
 		await expect(
-			execWithHardTimeout(childProcess, 'sleep 30', env, 300)
+			execWithHardTimeout(childProcess, 'node -e "setTimeout(function(){}, 30000)"', env, 500)
 		).rejects.toMatchObject({ code: 'ETIMEDOUT' });
-	});
+	}, 20000);
+});
 
+posixOnly('execWithHardTimeout process tree cleanup (POSIX)', () => {
 	test('kills the whole process tree on timeout, not just the shell', async () => {
 		// The shell backgrounds a grandchild and records its PID; after the
 		// timeout fires, that grandchild must be dead too — child_process.exec


### PR DESCRIPTION
Makes Windows support verifiable instead of assumed:

1. **Windows CI.** The build-and-test job now runs on a matrix of ubuntu-latest and windows-latest, so the TypeScript build and the test suite are exercised on Windows for every PR and master push.

2. **Cross-platform exec tests.** The basic execWithHardTimeout tests (resolve, stderr-on-failure, ETIMEDOUT) now use node -e commands so they run on both platforms — on Windows this exercises the cmd shell spawn path and the taskkill timeout path. The POSIX-shell fixtures (process-tree kill, orphan-pipe settlement) are gated to non-Windows since they depend on sh, $!, and ps.

3. **Platform-aware browser dropdown.** Settings offered Safari on Windows (whose cookies do not exist there) and omitted Edge. The dropdown now offers Chrome/Edge/Firefox on Windows and Chrome/Safari/Firefox elsewhere, and the whisperBrowser type is widened to match what the transcription service already supported.

Windows status after this PR: the yt-dlp preflight fix (PR #4) plus the venv-based yt-dlp with impersonation cover the script side (tiktok2text.py has Windows-aware venv paths, python vs python3, and taskkill handling); this PR adds the CI proof for build/tests and fixes the settings UI. End-to-end whisper transcription on a real Windows machine remains untested — flagged in the PR body rather than claimed.

Verification: npm test (61 tests) and npm run build pass locally; Windows CI job runs in this PR.