### PR TITLE
Fix: blank outputFolder (vault root) handled inconsistently across the plugin

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,7 @@ import {
 	extractSectionBody,
 	hasTag,
 	matchesStatusFilters,
+	noteInFolder,
 	normalizeTags,
 	pruneStaleSessions,
 	sortQueue,
@@ -2075,7 +2076,7 @@ export default class TikTokerPlugin extends Plugin {
 	private async getUntranscribedTikTokNotes(recentDays?: number): Promise<TFile[]> {
 		const tiktokFolder = this.settings.outputFolder;
 		const allFiles = this.app.vault.getMarkdownFiles()
-			.filter(file => file.path.startsWith(tiktokFolder + '/'));
+			.filter(file => noteInFolder(file.path, tiktokFolder));
 
 		const untranscribed: TFile[] = [];
 		const cutoffTime = recentDays ? Date.now() - (recentDays * 24 * 60 * 60 * 1000) : 0;
@@ -4307,11 +4308,11 @@ class TikTokReviewView extends ItemView {
 	}
 
 	async loadQueue() {
-		const tiktokFolder = this.plugin.settings.outputFolder || 'Tiktoks';
+		const tiktokFolder = this.plugin.settings.outputFolder;
 
-		// Get all files in the TikTok folder
+		// Get all files in the TikTok folder (a blank outputFolder means vault root)
 		const allFiles = this.app.vault.getMarkdownFiles()
-			.filter(file => file.path.startsWith(tiktokFolder + '/'));
+			.filter(file => noteInFolder(file.path, tiktokFolder));
 
 		// Combined filter logic (OR between status filters, starred ANDs)
 		this.queue = allFiles.filter(file => {
@@ -5007,8 +5008,9 @@ class TikTokReviewView extends ItemView {
 			return;
 		}
 
-		// Build dataview query based on active filters
-		const outputFolder = this.plugin.settings.outputFolder || 'Tiktoks';
+		// Build dataview query based on active filters (a blank outputFolder means
+		// vault root; Dataview's own `FROM ""` already matches every file)
+		const outputFolder = this.plugin.settings.outputFolder;
 		const result = buildDataviewQuery(
 			this.plugin.settings.reviewQueueDataviewTemplate,
 			outputFolder,

--- a/src/reviewQueue.ts
+++ b/src/reviewQueue.ts
@@ -19,6 +19,14 @@ export interface QueueStatusFilters {
 	starred: boolean;
 }
 
+// An empty outputFolder setting means "vault root" (this is how createTikTokNote
+// already treats it when building a note's path). Callers that list existing
+// notes back out of that folder must agree, or a blank outputFolder silently
+// matches zero files instead of every file.
+export function noteInFolder(path: string, folder: string): boolean {
+	return folder ? path.startsWith(folder + '/') : true;
+}
+
 // Frontmatter tags can arrive as a scalar, an array, or non-strings
 // (YAML parses a "#1111" hashtag saved without quotes as the int 1111).
 export function normalizeTags(tags: unknown): string[] {
@@ -226,7 +234,10 @@ export function buildDataviewQuery(template: string, folder: string, hashtagFilt
 	const query = [
 		'```dataview',
 		template,
-		`FROM "${folder}"`,
+		// An empty folder means vault root; omitting FROM is Dataview's own
+		// syntax for "search the whole vault", rather than relying on an
+		// empty-string path prefix to match everything.
+		...(folder ? [`FROM "${folder}"`] : []),
 		`WHERE ${clauses.join(' AND ')}`,
 		'```'
 	].join('\n');

--- a/test/unit/reviewQueue.test.ts
+++ b/test/unit/reviewQueue.test.ts
@@ -8,6 +8,7 @@ import {
 	firstContentHashtag,
 	hasTag,
 	matchesStatusFilters,
+	noteInFolder,
 	normalizeTags,
 	pruneStaleSessions,
 	sortQueue,
@@ -330,6 +331,27 @@ describe('buildDataviewQuery', () => {
 	test('escapes double quotes in filter values', () => {
 		const result = buildDataviewQuery('LIST', 'Tiktoks', '', 'say "hi"');
 		expect(result?.query).not.toContain('contains(file.text, "say "hi"")');
+	});
+
+	test('omits FROM entirely when folder is blank (vault root)', () => {
+		const result = buildDataviewQuery('LIST', '', 'manifest', '');
+		expect(result?.query).not.toContain('FROM');
+	});
+});
+
+describe('noteInFolder', () => {
+	test('matches everything when folder is blank (vault root)', () => {
+		expect(noteInFolder('My Note.md', '')).toBe(true);
+		expect(noteInFolder('Some/Nested/Note.md', '')).toBe(true);
+	});
+
+	test('only matches paths inside the given folder', () => {
+		expect(noteInFolder('Tiktoks/My Note.md', 'Tiktoks')).toBe(true);
+		expect(noteInFolder('Other/My Note.md', 'Tiktoks')).toBe(false);
+	});
+
+	test('does not match a differently-named folder with the same prefix', () => {
+		expect(noteInFolder('TiktoksArchive/My Note.md', 'Tiktoks')).toBe(false);
 	});
 });
 


### PR DESCRIPTION
Fixes #11.

## What

createTikTokNote already treats an empty outputFolder setting as vault root when building a note's path. loadQueue, getUntranscribedTikTokNotes, and insertDataviewToCurrentNote did not agree, so leaving Output folder blank silently breaks the review queue and the bulk untranscribed notes scan even though notes are created correctly.

## Changes

- Added noteInFolder(path, folder) to src/reviewQueue.ts. Blank folder matches every path, matching createTikTokNote's existing behavior.
- Used it in loadQueue() and getUntranscribedTikTokNotes() instead of the inconsistent startsWith / || 'Tiktoks' checks.
- buildDataviewQuery now omits the FROM clause entirely when folder is blank, which is Dataview's own syntax for searching the whole vault, instead of silently scoping to a Tiktoks folder that may not exist.
- Added regression tests for all of the above.

## Testing

- npm run build: typecheck and esbuild production build pass
- npm test: 91/91 passing (4 new tests added)
- Manually verified against a real vault with outputFolder set to an empty string: review queue populated correctly, bulk scan found untranscribed notes at vault root.

## Test plan for reviewer

- Set Output folder to blank
- Save and transcribe a TikTok note at vault root
- Confirm it appears in the review queue
- Confirm Find untranscribed notes picks up root level notes too